### PR TITLE
Fix navigator.deviceMemory in Firefox

### DIFF
--- a/common/wrappingS-DM.js
+++ b/common/wrappingS-DM.js
@@ -27,6 +27,11 @@
 		{
 			parent_object: "navigator",
 			parent_object_property: "deviceMemory",
+			helping_code: `
+				if (navigator.deviceMemory === undefined) {
+					return;
+				}
+			`,
 			wrapped_objects: [
 				{
 					original_name: "navigator.deviceMemory",


### PR DESCRIPTION
In Firefox navigator.deviceMemory can be undefined wrapping it leads to
error.