### PR TITLE
Moved shared code, added "shield OFF message"

### DIFF
--- a/chrome/http_shield_chrome.js
+++ b/chrome/http_shield_chrome.js
@@ -75,34 +75,6 @@ window.addEventListener("offline", function()
 	browser.webRequest.onErrorOccurred.removeListener(onErrorOccuredListener);
 });
 
-/// Check the storage for requestShieldOn boolean
-browser.storage.sync.get(["requestShieldOn"], function(result){
-	//If not found (initialization) or true
-	if (result.requestShieldOn == undefined || result.requestShieldOn)
-	{
-	//Hook up the listeners
-	browser.webRequest.onBeforeSendHeaders.addListener(
-		beforeSendHeadersListener,
-		{urls: ["<all_urls>"]},
-		["blocking", "requestHeaders"]
-	);
-
-	browser.webRequest.onHeadersReceived.addListener(
-		onHeadersReceivedRequestListener,
-		{urls: ["<all_urls>"]},
-		["blocking"]
-	);
-
-	browser.webRequest.onErrorOccurred.addListener(
-		onErrorOccuredListener,
-		{urls: ["<all_urls>"]}
-	);
-	}
-});
-
-/// Hook up the listener for receiving messages
-browser.runtime.onMessage.addListener(messageListener);
-
 /// webRequest event listener, hooked to onErrorOccured event
 /// Catches all errors, checks them for Request Timed out errors
 /// Iterates error counter, blocks the host if limit was exceeded
@@ -409,61 +381,8 @@ function notifyBlockedHost(host) {
 /// Does approriate action based on message text
 function messageListener(message, sender, sendResponse)
 {
-	//Message sent from options.js, whitelist was updated
-	if (message.message === "whitelist updated")
-	{
-		//Updating whitelist from storage
-		browser.storage.sync.get(["whitelistedHosts"], function(result){
-			doNotBlockHosts = result.whitelistedHosts;
-		});
-	}
-	//HTTP request shield was turned on
-	else if (message.message === "turn request shield on")
-	{
-		//Hook up the listeners
-		browser.webRequest.onBeforeSendHeaders.addListener(
-			beforeSendHeadersListener,
-			{urls: ["<all_urls>"]},
-			["blocking", "requestHeaders"]
-		);
-
-		browser.webRequest.onHeadersReceived.addListener(
-		onHeadersReceivedRequestListener,
-		{urls: ["<all_urls>"]},
-		["blocking"]
-		);
-
-		browser.webRequest.onErrorOccurred.addListener(
-			onErrorOccuredListener,
-			{urls: ["<all_urls>"]}
-		);
-	}
-	//HTTP request shield was turned off
-	else if (message.message === "turn request shield off")
-	{
-	//Disconnect the listeners
-	browser.webRequest.onBeforeSendHeaders.removeListener(beforeSendHeadersListener);
-	browser.webRequest.onHeadersReceived.removeListener(onHeadersReceivedRequestListener);
-	browser.webRequest.onErrorOccurred.removeListener(onErrorOccuredListener);
-	}
-	//Mesage came from popup.js, whitelist this site
-	else if (message.message === "add site to whitelist")
-	{
-		//Obtain current hostname and whitelist it
-		var currentHost = message.site;
-		doNotBlockHosts[currentHost] = true;
-		browser.storage.sync.set({"whitelistedHosts":doNotBlockHosts});
-	}
-	//Message came from popup.js, remove whitelisted site
-	else if (message.message === "remove site from whitelist")
-	{
-		//Obtain current hostname and remove it
-		currentHost = message.site;
-		delete doNotBlockHosts[currentHost];
-		browser.storage.sync.set({"whitelistedHosts":doNotBlockHosts});
-	}
 	//Message came from popup,js, asking whether is this site whitelisted
-	else if (message.message === "is current site whitelisted?")
+	if (message.message === "is current site whitelisted?")
 	{
 		//Read the current hostname
 		var currentHost = message.site;

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "author": "Libor Polčák, Martin Timko, Pavel Pohner",
   "background": {
-      "scripts": ["update.js", "url.js", "levels.js", "background.js", "http_shield_common.js", "http_shield_chrome.js"],
+      "scripts": ["update.js", "url.js", "levels.js", "background.js", "http_shield_chrome.js", "http_shield_common.js"],
       "persistent": true
   },
   "browser_action": {

--- a/common/popup.css
+++ b/common/popup.css
@@ -90,6 +90,10 @@ h3 {
 	grid-area:whitelist;
 }
 
+#shield_off_message{
+	font-size: large;
+}
+
 /* The switch - the box around the slider */
 .switch {
 	position: relative;

--- a/common/popup.html
+++ b/common/popup.html
@@ -25,7 +25,8 @@
 
 	<section id="http_shield_whitelist">
 	<h3>Network boundary shield</h3>
-	<div>
+	<p id="shield_off_message"></p>
+	<div id="http_shield_switch_wrapper">
 			<label id="switch-label">Shield enabled for this site:</label>
 			<label class="switch">
 				<input id="switch-checkbox" type="checkbox" checked>

--- a/common/popup.js
+++ b/common/popup.js
@@ -122,25 +122,37 @@ document.getElementsByClassName("slider")[0].addEventListener("click", () => {se
 function load_on_off_switch()
 {
 	var checkbox = document.getElementById("switch-checkbox");
-	var currentHost = "";
-	//Obtain URL of the current site
-	browser.tabs.query({currentWindow: true, active: true}, function (tabs) {
-		//Obtain hostname
-		currentHost = new URL(tabs[0].url);
-		currentHost = currentHost.hostname.replace(/^www\./,'');
-		//Ask background whether is this site whitelisted or not
-		browser.runtime.sendMessage({message:"is current site whitelisted?", site:currentHost}, function (response) {
-				//Check or uncheck the slider
-				if (response === "current site is whitelisted")
-				{
-					checkbox.checked = false;
-				}
-				else
-				{
-					checkbox.checked = true;
-				}
+
+	browser.storage.sync.get(["requestShieldOn"], function(result)
+	{
+		if (result.requestShieldOn === false)
+		{
+			document.getElementById("http_shield_switch_wrapper").style.display = "none";
+			document.getElementById("shield_off_message").innerHTML = "Network boundary shield is currently off.";
+		}	
+		else
+		{
+			var currentHost = "";
+			//Obtain URL of the current site
+			browser.tabs.query({currentWindow: true, active: true}, function (tabs) {
+				//Obtain hostname
+				currentHost = new URL(tabs[0].url);
+				currentHost = currentHost.hostname.replace(/^www\./,'');
+				//Ask background whether is this site whitelisted or not
+				browser.runtime.sendMessage({message:"is current site whitelisted?", site:currentHost}, function (response) {
+					//Check or uncheck the slider
+					if (response === "current site is whitelisted")
+					{
+						checkbox.checked = false;
+					}
+					else
+					{
+						checkbox.checked = true;
+					}
+				});
 			});
-		});
+		}
+	});
 }
 
 /// Event handler for On/off switch

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -1,7 +1,7 @@
 {
   "author": "Libor Polčák, Martin Timko, Pavel Pohner",
   "background": {
-      "scripts": ["update.js", "url.js", "levels.js", "background.js", "http_shield_common.js", "http_shield_firefox.js"]
+      "scripts": ["update.js", "url.js", "levels.js", "background.js", "http_shield_firefox.js", "http_shield_common.js"]
   },
   "browser_action": {
     "browser_style": true,


### PR DESCRIPTION
The majority of the shared code between both versions was moved to common file - http_shield_common, unfortunately, its neccessary to keep messageListener in both versions instead of moving it to the common file, because each browser is sending the response in the different manner and I did not find the way to unify that.

Added message into popup, that says, that Network boundary shield is offline. Message is replacing the "whitelist switch" when the shield is turned off.