### PR TITLE
Add wrapper for window.name.

### DIFF
--- a/common/levels.js
+++ b/common/levels.js
@@ -293,6 +293,17 @@ var wrapping_groups = {
 				"navigator.getBattery",
 			],
 		},
+		{
+			name: "windowname",
+			description: "Clear window.name value on the webpage loading.",
+			description2: [],
+			default: true,
+			options: [],
+			wrappers: [
+				// WINDOW-NAME
+				"window.name",
+			],
+		},
 	],
 }
 
@@ -395,6 +406,7 @@ var level_2 = {
 	"htmlcanvaselement": true,
 	"geolocation": true,
 	"geolocation_locationObfuscationType": 3,
+	"windowname": true,
 };
 
 var level_3 = {
@@ -420,6 +432,7 @@ var level_3 = {
 	"webworker_approach_slow": false,
 	"geolocation": true,
 	"geolocation_locationObfuscationType": 0,
+	"windowname": true,
 };
 
 // Level aliases

--- a/common/wrappingS-HTML.js
+++ b/common/wrappingS-HTML.js
@@ -1,0 +1,36 @@
+//
+//  JavaScript Restrictor is a browser extension which increases level
+//  of security, anonymity and privacy of the user while browsing the
+//  internet.
+//
+//  Copyright (C) 2020  Martin Bednar, Libor Polcak
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+/*
+ * Create private namespace
+ */
+(function() {
+	var wrappers = [
+		{
+			parent_object: "window",
+			parent_object_property: "name",
+			wrapped_objects: [],
+			helping_code: "window.name = '';",
+			nofreeze: true,
+		},
+	]
+	add_wrappers(wrappers);
+})()


### PR DESCRIPTION
Clear value of window.name property on page loading. Webpages will not be able to share ID value in window.name. This wrapper is active for level 2 and 3.