### PR TITLE
Integration tests: Enable automatic launch of Geo tests.

### DIFF
--- a/tests/integration_tests/testing/start.py
+++ b/tests/integration_tests/testing/start.py
@@ -45,7 +45,7 @@ def main():
             # set jsr_level to given level
             my_browser.jsr_level = jsr_level
             # run set of tests
-            pytest.main(['-s', '--ignore=testing/tests_definition/test_gps.py'])
+            pytest.main(['-s'])
             output.print_testing_footer(browser_type, jsr_level)
         # Close browser.
         my_browser.quit()


### PR DESCRIPTION
Geo tests are ignored now and must be run manually. This pull request changes setting of integration tests startup to Geo tests not be ignored. Geo tests have been already updated according to source code changes but I forgot to enable automatic launch for them. I am correcting this mistake in this pull request.