### PR TITLE
Integration tests: IOdevices test: Test only kind of device, not its id.

### DIFF
--- a/tests/integration_tests/testing/tests_definition/test_hw.py
+++ b/tests/integration_tests/testing/tests_definition/test_hw.py
@@ -62,7 +62,7 @@ def test_hardware_concurrency(browser, device, expected):
 def test_IOdevices(browser, IOdevices, expected):
 	if expected.device.IOdevices == 'REAL VALUE':
 		assert len(IOdevices) == len(browser.real.device.IOdevices)
-		for device in IOdevices:
-			assert any(realIOdevice['deviceId'] == device['deviceId'] for realIOdevice in browser.real.device.IOdevices)
+		for i in range(len(IOdevices)):
+			assert IOdevices[i]['kind'] == browser.real.device.IOdevices[i]['kind']
 	else:
 		assert len(IOdevices) == expected.device.IOdevices


### PR DESCRIPTION
Fix testing IO-devices on Linux based on comment: https://github.com/polcak/jsrestrictor/issues/100#issuecomment-827647253_