### PR TITLE
Unit tests: Update running unit tests according to changes by Giorgio.

### DIFF
--- a/tests/unit_tests/config/global-example.json
+++ b/tests/unit_tests/config/global-example.json
@@ -37,6 +37,12 @@
 					]
 				}
 			],
+			"replace_in_src": [
+				{
+					"origin": "browser.storage.sync.get(null).then(updateLevels);",
+					"new": "browser.storage.sync.get(null);"
+				}
+			],
 			"inject_code_to_src":
 			{
 				"begin": "code to be injected at the begging of source script after requirements",

--- a/tests/unit_tests/config/global-schema.json
+++ b/tests/unit_tests/config/global-schema.json
@@ -128,6 +128,26 @@
 								}
 							]
 						},
+						"replace_in_src": {
+							"type": "array",
+							"items": [
+								{
+									"type": "object",
+									"properties": {
+										"origin": {
+											"type": "string"
+										},
+										"new": {
+											"type": "string"
+										}
+									},
+									"required": [
+										"origin",
+										"new"
+									]
+								}
+							]
+						},
 						"inject_code_to_src": {
 							"type": "object",
 							"properties": {

--- a/tests/unit_tests/config/global.json
+++ b/tests/unit_tests/config/global.json
@@ -139,6 +139,12 @@
 					]
 				}
 			],
+			"replace_in_src": [
+				{
+					"origin": "browser.storage.sync.get(null).then(updateLevels);",
+					"new": "browser.storage.sync.get(null);"
+				}
+			],
 			"inject_code_to_src": 
 			{
 				"begin": "function gen_random32() { return 0.2 * 4294967295; }",

--- a/tests/unit_tests/start_unit_tests.sh
+++ b/tests/unit_tests/start_unit_tests.sh
@@ -124,6 +124,21 @@ for k in $(jq '.scripts | keys | .[]' ./config/global.json); do
 	fi
 	
 	
+	# Replace source code if required.
+	replace_in_src=$(jq -r '.replace_in_src' <<< "$script")
+	
+	if [[ $replace_in_src != "null" ]] ;
+	then
+		for l in $(jq '.replace_in_src | keys | .[]' <<< "$script"); do
+			# Get current replacement.
+			replacement=$(jq ".replace_in_src[$l]" <<< "$script")
+			origin=$(jq -r ".origin" <<< "$replacement")
+			new=$(jq -r ".new" <<< "$replacement")
+			sed -i "s/$origin/$new/" ./tmp/$source_script_name
+		done
+	fi
+	
+	
 	# Get code for injecting.
 	inject_code=$(jq -r '.inject_code_to_src' <<< "$script")
 	if [[ $inject_code != "null" ]] ;


### PR DESCRIPTION
Only one bugfix has to be applied on unit testing according to changes in levels.js by Giorgio (commit [c1443cf6b1d7ed6bba2a292379b91046a966bf06](https://github.com/polcak/jsrestrictor/commit/c1443cf6b1d7ed6bba2a292379b91046a966bf06)).
Sinon Chrome is used for spoofing browser.storage. But methods are only declared, but not defined. Just method browser.storage.sync.get returns undefined in Sinon Chrome, so following "then" failed. Following "than" has to be removed in testing environment.