### PR TITLE
Rebranding to JShelter

### DIFF
--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -32,7 +32,7 @@
       "256": "img/icon-256.png",
       "512": "img/icon-512.png"
     },
-    "default_title": "JavaScript Restrictor",
+    "default_title": "JShelter",
     "default_popup": "popup.html"
   },
   "content_scripts": [
@@ -54,7 +54,7 @@
     }
   ],
   "description": "Extension for increasing security and privacy level of the user.",
-  "homepage_url": "https://polcak.github.io/jsrestrictor/",
+  "homepage_url": "https://jshelter.org/",
   "icons": {
     "16": "img/icon-16.png",
     "32": "img/icon-32.png",
@@ -66,7 +66,7 @@
     "512": "img/icon-512.png"
   },
   "manifest_version": 2,
-  "name": "JavaScript Restrictor",
+  "name": "JShelter",
   "options_page": "options.html",
   "permissions": [
     "storage",

--- a/common/options.html
+++ b/common/options.html
@@ -39,7 +39,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 	<section class="content">
 
-    <h1>JavaScript Restrictor</h1>
+    <h1>JShelter</h1>
 
 <section id="configuration_area">
   <div id="levels-config">

--- a/common/popup.html
+++ b/common/popup.html
@@ -18,7 +18,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
 <body>
 
 	<img class="logo" id="logo" src="../img/icon-128.png" />
-	<h3 id="titletext">JavaScript Restrictor</h3>
+	<h3 id="titletext">JShelter</h3>
 	<img id="controls" src="../img/settings-128.png" title="Open settings"/>
 
 	<section id="level_controls">

--- a/common/update.js
+++ b/common/update.js
@@ -46,7 +46,7 @@ function installUpdate() {
 	browser.storage.sync.get(null).then(function (item) {
 		if (!item.hasOwnProperty("version") || (item.version < 2.1)) {
 			browser.storage.sync.clear();
-			console.log("All JavaScript Restrictor data cleared! Unfortunately, we do not migrate settings from versions bellow 0.3.");
+			console.log("All JShelter data cleared! Unfortunately, we do not migrate settings from versions bellow 0.3.");
 			item = {
 				__default__: 2,
 				version: 2.1,

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -3,5 +3,5 @@ defaults:
     scope:
        path: ""
     values:
-      title: JavaScript Restrictor
+      title: JShelter
       layout: default

--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -3,7 +3,7 @@
 		project was funded through the NGI0 PET Fund, a fund established by NLnet with financial support
 		from the European Commission's Next Generation Internet programme, under the aegis of DG
 		Communications Networks, Content and Technology under grant agreement No 825310 as
-		<a href="https://nlnet.nl/project/JSRestrictor/">JavaScript Restrictor</a> and <a
+		<a href="https://nlnet.nl/project/JSRestrictor/">JShelter</a> and <a
 			 href="https://nlnet.nl/project/JavascriptShield/">JavaScript Shield</a> projects. This
 		project was supported by the <a href="https://www.fit.vut.cz/research/project/1063/.en">MV CR	VI20172020062 project</a>.
 		This program is free software: you can redistribute it and/or modify

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,20 +1,20 @@
-> **Disclaimer**: This is a research project under development, see the [issue page](https://github.com/polcak/jsrestrictor/issues) and the [webextension home page](https://polcak.github.io/jsrestrictor/) for more details about the current status.
+> **Disclaimer**: This is a research project under development, see the [issue page](https://github.com/polcak/jsrestrictor/issues) and the [webextension home page](https://jshelter.org) for more details about the current status.
 
-A JS-enabled web page can access any of the APIs that a web browser provides. The user has only a limited control and some APIs cannot be restricted by the user easily. JavaScript Restrictor aims to improve the user control of the web browser. Similarly to a firewall that controls the network traffic, JavaScript Restrictor controls the APIs provided by the browser. The goal is to improve the privacy and security of the user running the extension.
+A JS-enabled web page can access any of the APIs that a web browser provides. The user has only a limited control and some APIs cannot be restricted by the user easily. JShelter aims to improve the user control of the web browser. Similarly to a firewall that controls the network traffic, JShelter controls the APIs provided by the browser. The goal is to improve the privacy and security of the user running the extension.
 
 ## Installation
 
-JavaScript Restrictor (JSR) is a browser extension with support for multiple browsers: [Firefox](https://addons.mozilla.org/firefox/addon/javascript-restrictor/), [Google Chrome](https://chrome.google.com/webstore/detail/javascript-restrictor/ammoloihpcbognfddfjcljgembpibcmb), and [Opera](https://addons.opera.com/extensions/details/javascript-restrictor/). The extension also works with Brave, Microsoft Edge, and most likely any Chromium-based browser. [Let us know](https://github.com/polcak/jsrestrictor/issues) if you want to add the extension to additional stores.
+JShelter is a browser extension with support for multiple browsers: [Firefox](https://addons.mozilla.org/firefox/addon/javascript-restrictor/), [Google Chrome](https://chrome.google.com/webstore/detail/javascript-restrictor/ammoloihpcbognfddfjcljgembpibcmb), and [Opera](https://addons.opera.com/extensions/details/javascript-restrictor/). The extension also works with Brave, Microsoft Edge, and most likely any Chromium-based browser. [Let us know](https://github.com/polcak/jsrestrictor/issues) if you want to add the extension to additional stores.
 
 ## Goals
 
-Various websites collect information about users without their awareness. The collected information is used to track users. Malicious websites can fingerprint user browsers or computers. JavaScript Restrictor protects the user by restricting or modifying several web browser APIs used to create side-channels and identify the user, the browser or the computer. JavaScript Restrictor can block access to JavaScript objects, functions and properties or provide a less precise implementation of their functionality, for example, by modifying or spoofing values returned by the JS calls. The goal is to mislead websites by providing false data or no data at all.
+Various websites collect information about users without their awareness. The collected information is used to track users. Malicious websites can fingerprint user browsers or computers. JShelter protects the user by restricting or modifying several web browser APIs used to create side-channels and identify the user, the browser or the computer. JShelter can block access to JavaScript objects, functions and properties or provide a less precise implementation of their functionality, for example, by modifying or spoofing values returned by the JS calls. The goal is to mislead websites by providing false data or no data at all.
 
 Another goal of the extension is not to break the visited websites. As the deployment of JavaScript only websites rise, it is necessary to fine-tune the API available to the websites to prevent unsolicited tracking and protect against data thefts.
 
 ### Protected APIs
 
-JavaScript Restrictor currently supports modifying and restricting the following APIs (for more details visit [levels of protection page](https://polcak.github.io/jsrestrictor/levels.html)):
+JShelter currently supports modifying and restricting the following APIs (for more details visit [levels of protection page](https://jshelter.org/levels/)):
 
 * **Network boundary shield** (NBS) prevents web pages to use the browser as a proxy between local network and the public Internet. See the [Force Point report](https://www.forcepoint.com/sites/default/files/resources/files/report-attacking-internal-network-en_0.pdf) for an example of the attack. The protection encapsulates the WebRequest API, so it captures all outgoing requests including all elements created by JavaScript.
 * **window.Date object**, **window.performance.now()**, **window.PerformanceEntry**, **Event.prototype.timeStamp**, **Gamepad.prototype.timestamp**, and **VRFrameData.prototype.timestamp** provide high-resolution timestamps that can be used to [idenfity the user](http://www.jucs.org/jucs_21_9/clock_skew_based_computer) or can be used for microarchitectural attacks and [timing attacks](https://lirias.kuleuven.be/retrieve/389086).
@@ -48,16 +48,16 @@ Note that the spoofing and rounding actions performed by the extension can break
 
 ### Levels of Protection
 
-JavaScript Restrictor provides four in-built levels of protection:
+JShelter provides four in-built levels of protection:
 
-* 0 - the functionality of the extension is turned off. All web pages are displayed as intended without any interaction from JavaScript Restrictor.
+* 0 - the functionality of the extension is turned off. All web pages are displayed as intended without any interaction from JShelter.
 * 1 - the minimal level of protection. Only changes that should not break most pages are enabled.
 	Note that timestamps are rounded so pages relying on precise time may be broken.
 * 2 - intended to be used as a default level of protection, this level should not break any site
 	while maintaining strong protection.
 * 3 - maximal level of protection: enable all functionality.
 
-For more accurate description of the restrictions see [levels of protection page](https://polcak.github.io/jsrestrictor/levels.html).
+For more accurate description of the restrictions see [levels of protection page](https://jshelter.org/levels/).
 
 The default level of protection can be set by a popup (clicking on JSR icon) or through options of the extension. Specific level of protection for specific domains can be set in options by adding them to the list of websites with specific level of protection. This can be done also by a popup during a visit of the website.
 

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -1,6 +1,6 @@
 # Permissions
 
-*Javascript Restrictor* requires these permissions:
+*JShelter* requires these permissions:
  * **storage --** *used for storing extension configuration and user options*
  * **tabs --** *used for updating icon badge of the extension on tab change*
  * **webRequest, webRequestBlocking, and all_urls --** *needed for modyfing JavaScript objects and APIs on all pages and also used for capturing and blocking malicious HTTP requests (Network Boundary Shield)*

--- a/docs/test/test.html
+++ b/docs/test/test.html
@@ -28,7 +28,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
 </head>
 <body onload="initClock(); updatePerformanceLabelEvery(200); getHW();">
 	<p><a href="https://polcak.github.io/jsrestrictor/">Home Page</a></p>
-	<p>You can try <a href="https://amiunique.org/">Am I Unique</a> or <a href="https://panopticlick.eff.org/">Panopticlick</a> to learn how identifiable you are on the Internet and test JavaScript Restrictor Extension</p>
+	<p>You can try <a href="https://amiunique.org/">Am I Unique</a> or <a href="https://panopticlick.eff.org/">Panopticlick</a> to learn how identifiable you are on the Internet and test JShelter Extension</p>
 	<hr>
 	
 	<h1>jShelter Test Page</h1>

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -31,7 +31,7 @@
       "256": "img/icon-256.png",
       "512": "img/icon-512.png"
     },
-    "default_title": "JavaScript Restrictor",
+    "default_title": "JShelter",
     "default_popup": "popup.html"
   },
   "content_scripts": [
@@ -52,7 +52,7 @@
     }
   ],
   "description": "Extension for increasing security and privacy level of the user.",
-  "homepage_url": "https://polcak.github.io/jsrestrictor/",
+  "homepage_url": "https://jshelter.org/",
   "icons": {
     "16": "img/icon-16.png",
     "32": "img/icon-32.png",
@@ -64,7 +64,7 @@
     "512": "img/icon-512.png"
   },
   "manifest_version": 2,
-  "name": "JavaScript Restrictor",
+  "name": "JShelter",
   "options_ui": {
     "page": "options.html",
     "open_in_tab": true

--- a/tests/integration_tests/README.md
+++ b/tests/integration_tests/README.md
@@ -1,6 +1,6 @@
 # Instruction how to run integration tests
 
-Integration tests for web browser extension Javascript Restrictor automatically verify that
+Integration tests for web browser extension JShelter automatically verify that
 required JavaScript API is wrapped and conversely, that non-wrapped JavaScript API provides real values.
 
 It is necessary to partially set up manually a test environment before the first test run!


### PR DESCRIPTION
The schedule for the rebranding is:

- [x] 1a-I Deploy the web https://jshelter.org/.
- [ ] 1a-II Make sure that all changes from https://polcak.github.io/jsrestrictor/ are on the new page as well.
- [ ] 1b. Move repository to JShelter.
- [ ] 2. Fix the links in the codebase to point to the rebranded web/repo.
- [ ] 3. Deploy redirects from Github to the new pages.
- [ ] 4a. Rewrite all strings like JSR, JS Restrictor, JavaScript Restrictor in the  code base to JShelter.
- [ ] 4b. Change the name of the extension in stores with the 0.6 release: when we have new GUI, fingerprint blocker (fpd branch).

For more context, see also #136