### PR TITLE
Move logo to the left side on 1366x768

### DIFF
--- a/common/options.css
+++ b/common/options.css
@@ -46,7 +46,7 @@ footer {
 	}
 }
 
-@media (min-width: 1300px) {
+@media (min-width: 1367px) {
 	body {
 		/*  Redefine the grid into a three column layout with empty space on the left and right. */
 		grid-template-columns: 1fr 10em 1000px 10% 1fr;


### PR DESCRIPTION
On 1366x768 screen resolution, the JShelter logo on main settings page is on the right site that causes horizontal scrolling:
![0](https://github.com/polcak/jsrestrictor/assets/14265316/9169efb3-134a-41d7-b539-8063736442fb)
This PR fixes it by moving the logo to the left side:
![1](https://github.com/polcak/jsrestrictor/assets/14265316/513c4e20-b47e-4ebb-961b-471c2c65c42e)
P.S. I'd recommend to consider moving logo to the left side for all resolutions, even higher than this one. There's no need it to be on the right side, it's just a waste of space horizontally.